### PR TITLE
Generalize `<ab>` prefix rendering using attribute-driven labels

### DIFF
--- a/js/parser.js
+++ b/js/parser.js
@@ -364,14 +364,8 @@ const QZHParser = (function() {
             
             case 'ab':
                 const place = node.getAttribute('place');
-                const abType = (node.getAttribute('type') || '').toLowerCase();
                 const abClass = place ? 'tei-ab tei-ab1' : 'tei-ab';
-                let abPrefix = '';
-                if (abType === 'dorsal') {
-                    const dorsalN = node.getAttribute('n') || '';
-                    const dorsalLabel = dorsalN ? `S. ${dorsalN}` : 'verso';
-                    abPrefix = `<span class="pb-marker tei-ab-dorsal-marker" data-tooltip="Verso-Angabe" data-tooltip-type="page">[${escapeHTML(dorsalLabel)}]</span> `;
-                }
+                const abPrefix = buildAbMarker(node);
                 return `<div class="${abClass}">${abPrefix}${children}</div>`;
             
             case 'head':
@@ -940,6 +934,45 @@ const QZHParser = (function() {
         }
 
         return parts.join(' | ');
+    }
+
+    /**
+     * Build a marker-like prefix for <ab> based on key attributes
+     */
+    function buildAbMarker(node) {
+        const relevantAttrs = ['type', 'place', 'n'];
+        const attrs = relevantAttrs
+            .map(name => [name, node.getAttribute(name) || ''])
+            .filter(([, value]) => Boolean(value));
+
+        if (attrs.length === 0) {
+            return '';
+        }
+
+        const fullLabel = attrs
+            .map(([name, value]) => `${name}=${value}`)
+            .join(', ');
+
+        let inlineAttrs = attrs;
+        if (fullLabel.length > 40) {
+            inlineAttrs = attrs.filter(([name]) => name === 'type' || name === 'place');
+            if (inlineAttrs.length === 0) {
+                inlineAttrs = [attrs[0]];
+            }
+        }
+
+        const inlineLabel = inlineAttrs
+            .map(([name, value]) => `${name}=${value}`)
+            .join(', ');
+
+        const tooltipText = buildAttributeTooltip(node, {
+            type: 'type',
+            place: 'place',
+            n: 'n'
+        });
+        const tooltip = tooltipText ? ` data-tooltip="${escapeAttr(tooltipText)}" data-tooltip-type="page"` : '';
+
+        return `<span class="pb-marker tei-ab-marker"${tooltip}>[${escapeHTML(inlineLabel)}]</span> `;
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Replace the brittle special-case `dorsal` handling for `<ab>` blocks with a generic, attribute-driven marker so all `type`/`place` (and optional `n`) variants render a visible, consistent prefix while preserving existing typography classes.

### Description
- Replaced the `dorsal` branch in `case 'ab'` inside `transformNode()` with a call to `buildAbMarker(node)` and left the container classes (`tei-ab`, `tei-ab1`) unchanged.
- Added `buildAbMarker(node)` which reads `type`, `place`, and optional `n`, composes an inline bracketed label and returns a `pb-marker`-style span to be prepended to the `<ab>` content.
- Reused `buildAttributeTooltip()` to create a `data-tooltip` with the full attribute list and added inline truncation logic (prefer `type`/`place`) when the label is long.
- Kept visual/semantic behavior consistent by using existing marker styling (returns a span with `pb-marker` and `data-tooltip` where appropriate).

### Testing
- Started a local server with `python3 -m http.server 4173` and loaded the app to exercise the live rendering code.
- Ran a Playwright-based DOM test that fetched `sample/QZH_073.xml`, ran `QZHParser.parse()` and `QZHParser.transform()`, injected the result into the page, and took a screenshot (`artifacts/ab-marker-qzh073.png`).
- Verified DOM assertions showing markers such as `[type=marginal note, place=left margin]` and `[type=dorsal, place=verso]` with corresponding `data-tooltip` content, and all automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a586d46b408328900fe3565070b3e5)